### PR TITLE
add all CrossBrowserTesting-Specific Capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,12 @@ testCafe
 
 ## Configuration
 
-Use the following environment variables to set additional configuration options:
+Use the following environment variables to set additional [configuration options](https://help.crossbrowsertesting.com/selenium-testing/tutorials/crossbrowsertesting-automation-capabilities/):
 
- - `CBT_MAX_DURATION` - By default, a test will have a maximum run time of 600 seconds (10 minutes). If you need more time you can change that by passing the max_duration capability along with a value.The highest value is 14400 seconds (4 hours). [More details](https://help.crossbrowsertesting.com/selenium-testing/faq/default-duration-selenium-test-timeout-information/)  
+- `CBT_BUILD` - Number of the build within your test to get a high-level view of build performance.
+- `CBT_RECORD_VIDEO` - Start a video recording of your screen during the test session. (max length 10 minutes)
+- `CBT_RECORD_NETWORK` - Start a recording of your network packets during the test session.
+ - `CBT_MAX_DURATION` - By default, a test will have a maximum run time of 600 seconds (10 minutes). If you need more time you can change that by passing the max_duration capability along with a value.The highest value is 14400 seconds (4 hours). [More details](https://help.crossbrowsertesting.com/selenium-testing/faq/default-duration-selenium-test-timeout-information/)
 
 ## Author
 Sijo Cheeran (https://synacor.com)

--- a/src/index.js
+++ b/src/index.js
@@ -8,8 +8,6 @@ import wd from 'wd';
 var openedBrowsers = {};
 var webDriver;
 
-const MAX_DURATION     = process.env['CBT_MAX_DURATION'];
-
 const AUTH_FAILED_ERROR = 'Authentication failed. Please assign the correct username and access key ' +
     'to the CBT_TUNNELS_USERNAME and CBT_TUNNELS_AUTHKEY environment variables.';
 
@@ -136,12 +134,13 @@ export default {
                 }
 
                 // CrossBrowserTesting-Specific Capabilities
-                if (MAX_DURATION)
-                    capabilities.max_duration = MAX_DURATION;
-
                 capabilities.name = `TestCafe test run ${id}`;
-                capabilities.build = process.env.CBT_TUNNELS_BUILD || null;
-                capabilities.record_video = (process.env.CBT_TUNNELS_RECORD_VIDEO || '').match(/true/i); // eslint-disable-line camelcase
+                if (process.env.CBT_BUILD)
+                    capabilities.build = process.env.CBT_BUILD;
+                if (process.env.CBT_RECORD_VIDEO)
+                    capabilities.record_video = process.env.CBT_RECORD_VIDEO.match(/true/i);
+                if (process.env.CBT_MAX_DURATION)
+                    capabilities.max_duration = process.env.CBT_MAX_DURATION;
 
                 await startBrowser(id, pageUrl, capabilities);
             }

--- a/src/index.js
+++ b/src/index.js
@@ -139,6 +139,8 @@ export default {
                     capabilities.build = process.env.CBT_BUILD;
                 if (process.env.CBT_RECORD_VIDEO)
                     capabilities.record_video = process.env.CBT_RECORD_VIDEO.match(/true/i);
+                if (process.env.CBT_RECORD_NETWORK)
+                    capabilities.record_video = process.env.CBT_RECORD_NETWORK.match(/true/i);
                 if (process.env.CBT_MAX_DURATION)
                     capabilities.max_duration = process.env.CBT_MAX_DURATION;
 

--- a/src/index.js
+++ b/src/index.js
@@ -122,7 +122,7 @@ export default {
                         version:     version,
                         platform:    platform
                     };
-                } 
+                }
                 else {
                     capabilities = {
                         browserName:     browserName,
@@ -131,7 +131,10 @@ export default {
                     };
                 }
 
+                // CrossBrowserTesting-Specific Capabilities
                 capabilities.name = `TestCafe test run ${id}`;
+                capabilities.build = process.env.CBT_TUNNELS_BUILD || null;
+                capabilities.record_video = (process.env.CBT_TUNNELS_RECORD_VIDEO || '').match(/true/i); // eslint-disable-line camelcase
 
                 await startBrowser(id, pageUrl, capabilities);
             }


### PR DESCRIPTION
added environment variables to allow all CrossBrowserTesting-Specific Capabilities

- `CBT_BUILD`
- `CBT_RECORD_VIDEO`
- `CBT_RECORD_NETWORK`

**note**: i have noticed that recording of video and/or network is dependent on the browser combination
@sijosyn please review and merge