### PR TITLE
Add support for passing Chrome args

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Use the following environment variables to set additional [configuration options
 - `CBT_RECORD_VIDEO` - Start a video recording of your screen during the test session. (max length 10 minutes)
 - `CBT_RECORD_NETWORK` - Start a recording of your network packets during the test session.
  - `CBT_MAX_DURATION` - By default, a test will have a maximum run time of 600 seconds (10 minutes). If you need more time you can change that by passing the max_duration capability along with a value.The highest value is 14400 seconds (4 hours). [More details](https://help.crossbrowsertesting.com/selenium-testing/faq/default-duration-selenium-test-timeout-information/)
+- `CBT_CHROME_ARGS` - Extra arguments to pass to Chrome.  e.g. `--autoplay-policy=no-user-gesture-required`
 
 ## Author
 Sijo Cheeran (https://synacor.com)

--- a/src/index.js
+++ b/src/index.js
@@ -144,6 +144,9 @@ export default {
                 if (process.env.CBT_MAX_DURATION)
                     capabilities.max_duration = process.env.CBT_MAX_DURATION;
 
+                if (browserName.indexOf('Chrome') !== -1 && process.env.CBT_CHROME_ARGS && process.env.CBT_CHROME_ARGS.length > 0)
+                    capabilities.chromeOptions = { args: [process.env.CBT_CHROME_ARGS] };
+
                 await startBrowser(id, pageUrl, capabilities);
             }
 


### PR DESCRIPTION
This adds support for passing arguments to Chrome. The syntax is the same as the BrowserStack provider.