### PR TITLE
Fix record_network option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -144,7 +144,7 @@ export default {
                 if (process.env.CBT_RECORD_VIDEO)
                     capabilities.record_video = process.env.CBT_RECORD_VIDEO.match(/true/i);
                 if (process.env.CBT_RECORD_NETWORK)
-                    capabilities.record_video = process.env.CBT_RECORD_NETWORK.match(/true/i);
+                    capabilities.record_network = process.env.CBT_RECORD_NETWORK.match(/true/i);
                 if (process.env.CBT_MAX_DURATION)
                     capabilities.max_duration = process.env.CBT_MAX_DURATION;
 


### PR DESCRIPTION
It looks like a copy/paste went slightly wrong when `record_video` and `record_network` were added. I've corrected that typo.

disclosure: I haven't tested this, just noticed it whilst reading through the code